### PR TITLE
fix: filter style consistency + TOC active-chunk highlight

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -26,6 +26,7 @@ export default function App() {
   } = useSettings();
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [hiddenBlockTypes, setHiddenBlockTypes] = useState<Set<string>>(new Set());
+  const [activeChunkId, setActiveChunkId] = useState<string | null>(null);
   const handleToggleBlockType = useCallback((type: string) => {
     setHiddenBlockTypes((prev) => {
       const next = new Set(prev);
@@ -140,6 +141,7 @@ export default function App() {
               showMinimap={showMinimap}
               highlightedBlockId={search.currentBlockId}
               onCollapseControlsReady={handleCollapseControlsReady}
+              onActiveChunkChange={setActiveChunkId}
             />
           </main>
 
@@ -163,6 +165,7 @@ export default function App() {
               onGranularityChange={setGranularity}
               onCollapseAll={collapseControls?.collapseAll}
               onExpandAll={collapseControls?.expandAll}
+              activeChunkId={activeChunkId}
             />
           </aside>
         </div>

--- a/src/ui/components/BlockFilter.tsx
+++ b/src/ui/components/BlockFilter.tsx
@@ -40,18 +40,11 @@ export function BlockFilter({ hiddenTypes, onToggleType }: Props) {
           >
             <span>{type}</span>
             <span
-              className="w-7 h-4 rounded-full relative transition-all"
+              className="w-3 h-3 rounded-full border border-white/30"
               style={{
-                backgroundColor: isVisible ? theme.colors.accent : 'rgba(255,255,255,0.15)',
+                backgroundColor: isVisible ? theme.colors.accent : 'transparent',
               }}
-            >
-              <span
-                className="absolute top-0.5 w-3 h-3 rounded-full bg-white transition-all"
-                style={{
-                  left: isVisible ? '14px' : '2px',
-                }}
-              />
-            </span>
+            />
           </button>
         );
       })}

--- a/src/ui/components/Footer.tsx
+++ b/src/ui/components/Footer.tsx
@@ -65,38 +65,36 @@ export function Footer({
           </span>
         )}
       </div>
-      <div className="relative">
-        <button
-          className="px-2 py-1 rounded transition-colors"
-          style={{
-            backgroundColor: filterOpen ? 'rgba(255,255,255,0.15)' : 'transparent',
-            opacity: filterOpen ? 1 : 0.6,
-          }}
-          onMouseDown={(e) => {
-            e.stopPropagation();
-          }}
-          onClick={() => {
-            setFilterOpen((prev) => !prev);
-          }}
-        >
-          Filter{hiddenBlockTypes.size > 0 ? ` (${String(hiddenBlockTypes.size)})` : ''}
-        </button>
-        {filterOpen && (
-          <div
-            className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 rounded-lg shadow-lg border border-white/10 p-4"
+      <div className="flex items-center gap-2">
+        <div className="relative">
+          <button
+            className="px-2 py-1 rounded transition-colors"
             style={{
-              backgroundColor: theme.colors.headerBg,
-              color: theme.colors.headerText,
+              backgroundColor: filterOpen ? 'rgba(255,255,255,0.15)' : 'transparent',
+              opacity: filterOpen ? 1 : 0.6,
+            }}
+            onMouseDown={(e) => {
+              e.stopPropagation();
+            }}
+            onClick={() => {
+              setFilterOpen((prev) => !prev);
             }}
           >
-            <h3 className="text-sm font-semibold mb-3">Block Type Filter</h3>
-            <BlockFilter hiddenTypes={hiddenBlockTypes} onToggleType={onToggleBlockType} />
-          </div>
-        )}
-      </div>
-
-      <div className="flex items-center gap-2">
-        <span className="w-px h-4 bg-white/20" />
+            Filter{hiddenBlockTypes.size > 0 ? ` (${String(hiddenBlockTypes.size)})` : ''}
+          </button>
+          {filterOpen && (
+            <div
+              className="absolute bottom-full right-0 mb-2 w-56 rounded-lg shadow-lg border border-white/10 p-4"
+              style={{
+                backgroundColor: theme.colors.headerBg,
+                color: theme.colors.headerText,
+              }}
+            >
+              <h3 className="text-sm font-semibold mb-3">Block Type Filter</h3>
+              <BlockFilter hiddenTypes={hiddenBlockTypes} onToggleType={onToggleBlockType} />
+            </div>
+          )}
+        </div>
         <div className="relative">
           <button
             className="px-2 py-1 rounded transition-colors"


### PR DESCRIPTION
## Summary
- **Filter button repositioned**: Moved from center of footer back to the right side, next to Settings button. Removed the vertical divider between them.
- **Filter toggle style**: Changed BlockFilter toggles from slider-style switches to round radio-button indicators (filled circle when active), matching the SettingsPanel pattern for visual consistency.
- **TOC active-chunk highlight**: When scrolling/panning the graph viewport, the IndexSidebar TOC now highlights which chunk is currently in view. Uses viewport center proximity detection (debounced 200ms) with accent-colored left border + subtle background highlight, and auto-scrolls the active chunk into view.

## Files changed
- `src/ui/components/Footer.tsx` -- Moved filter `<div>` into right-side flex container next to settings
- `src/ui/components/BlockFilter.tsx` -- Replaced slider toggle with round radio-button indicator
- `src/ui/components/graph/GraphView.tsx` -- Added `onActiveChunkChange` prop + debounced viewport tracking
- `src/ui/App.tsx` -- Added `activeChunkId` state, wired between GraphView and IndexSidebar
- `src/ui/components/IndexSidebar.tsx` -- Added `activeChunkId` prop, visual highlight + auto-scroll

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint 'src/**/*.{ts,tsx}'` passes
- [x] `npx vitest run` -- 247/247 tests pass
- [x] `npm run build` succeeds
- [ ] Manual verification: filter and settings buttons side by side in footer
- [ ] Manual verification: filter toggles show round dot style
- [ ] Manual verification: scrolling graph highlights corresponding chunk in sidebar TOC

Generated with [Claude Code](https://claude.com/claude-code)